### PR TITLE
Video

### DIFF
--- a/src/main/java/edu/cmu/cs/stage3/alice/authoringtool/dialog/CaptureContentPane.java
+++ b/src/main/java/edu/cmu/cs/stage3/alice/authoringtool/dialog/CaptureContentPane.java
@@ -291,8 +291,8 @@ public class CaptureContentPane extends edu.cmu.cs.stage3.swing.ContentPane {
 		authoringTool.stopWorld();
 		statusFrame.setVisible(false);
 		timeLabel.setBackground(java.awt.Color.GREEN);
-		setClear(false);
 		setButtonsCapturing(false);
+		setClear(false);
 
 		endCapturing = false;
 		running = false;

--- a/src/main/java/edu/cmu/cs/stage3/alice/authoringtool/dialog/CaptureContentPane.java
+++ b/src/main/java/edu/cmu/cs/stage3/alice/authoringtool/dialog/CaptureContentPane.java
@@ -826,6 +826,7 @@ public class CaptureContentPane extends edu.cmu.cs.stage3.swing.ContentPane {
 
 	// have we finished capturing?
 	public boolean getEnd() {
+		Thread.yield();
 		return endCapturing;
 	}
 
@@ -1274,12 +1275,12 @@ public class CaptureContentPane extends edu.cmu.cs.stage3.swing.ContentPane {
 		public void run() {
 			java.text.DecimalFormat det = new java.text.DecimalFormat("00");
 			while (endCapturing != false) {
+				try {
+					Thread.sleep(1000);
+				} catch (InterruptedException e) {
+					e.printStackTrace();
+				}
 				if (getRunning()) {
-					try {
-						Thread.sleep(1000);
-					} catch (InterruptedException e) {
-						e.printStackTrace();
-					}
 					timer++;
 					int seconds = timer % 60;
 					int minutes = timer / 60;

--- a/src/main/java/edu/cmu/cs/stage3/alice/authoringtool/dialog/CaptureContentPane.java
+++ b/src/main/java/edu/cmu/cs/stage3/alice/authoringtool/dialog/CaptureContentPane.java
@@ -1157,7 +1157,7 @@ public class CaptureContentPane extends edu.cmu.cs.stage3.swing.ContentPane {
 			m = null;
 			sources.clear();
 			sources = null;
-//			pulsing = false;
+			pulsing = false;
 			try {
 				pulse.join();
 			} catch (InterruptedException e) {


### PR DESCRIPTION
 Solution of my problems with Video Export Window in Alice2.5.4: 

 - On Linux OpenJDK java Video Ecoding Window stops responding during never-ending encoding.
 CPU keeps working 100% for java than. Window Oracle HotSpot java is not affected.
Adding sleep() and yield() into loops  helps in this situation.

-After finishing video encoding, small "Merging_Sound_and_Audio" window keeps running forever.
Reason: variable pulsing for enabling thread stopping was accidedently commented out. I reverse it back.

- When Video ecoding window is displayed more then once, encodeButton shows itself as enabled
 at the window start. Reason:
Methods   setButtonsCapturing(false) and setClear(false) use different encodeButton.setEnable() value; the last one wins.
