### PR TITLE
Corrections for non-english locale chars on java > 8

### DIFF
--- a/src/main/java/edu/cmu/cs/stage3/io/ZipFileTreeStorer.java
+++ b/src/main/java/edu/cmu/cs/stage3/io/ZipFileTreeStorer.java
@@ -229,14 +229,14 @@ public class ZipFileTreeStorer implements edu.cmu.cs.stage3.io.DirectoryTreeStor
             fileName = new String(name);
             // Aik Min - Recompute file length for names with extended characters since those characters requires 2 byte to store them
             try {
-				fileNameLength = new String (fileName.getBytes(), "ISO-8859-1").length();
+				fileNameLength = fileName.getBytes("UTF-8").length;
 			} catch (UnsupportedEncodingException e) {
 				// TODO Auto-generated catch block
 				e.printStackTrace();
 			}
             if (localHeaderReference != null){
                 localHeaderReference.fileName = new String(fileName);
-                localHeaderReference.fileNameLength = fileName.length();
+                localHeaderReference.fileNameLength = fileNameLength;
             }
         }
 

--- a/src/main/java/edu/cmu/cs/stage3/io/ZipTreeStorer.java
+++ b/src/main/java/edu/cmu/cs/stage3/io/ZipTreeStorer.java
@@ -86,7 +86,7 @@ public class ZipTreeStorer implements DirectoryTreeStorer {
 			throw new IllegalArgumentException( Messages.getString("pathname_has_no_length") ); 
 		}
 		
-		String path = new String ((currentDirectory + pathname + "/").getBytes(), "ISO-8859-1") ;
+		String path = new String (currentDirectory + pathname + "/") ;
 		java.util.zip.ZipEntry newEntry = new java.util.zip.ZipEntry( path ); 
 		if( zipOut != null ) {
 			zipOut.putNextEntry( newEntry );

--- a/src/main/java/edu/cmu/cs/stage3/lang/Messages.java
+++ b/src/main/java/edu/cmu/cs/stage3/lang/Messages.java
@@ -10,11 +10,7 @@ public class Messages {
 		try {	
 			String t = (String)ResourceBundle.getBundle("edu.cmu.cs.stage3.lang.messages", AikMin.locale).getObject(key);
 			t = t.replace("''", "'");
-			//if (AikMin.locale.equals(new Locale("ar"))){
-				return new String ( t.getBytes("ISO-8859-1"), "UTF-8" );
-			//}
-			//t.replace("''", "'");
-			//return (String)ResourceBundle.getBundle("edu.cmu.cs.stage3.lang."+AikMin.locale).getObject(key);
+			return t; //already converted from UTF-8 properties
 		} catch (MissingResourceException e) {
 			return key.replace("_", " ");
 		} catch (Exception ee){


### PR DESCRIPTION
  When I tried Alice2.5.4.RC1 on OpenJDK java 11 or 17, English version works OK. 
(My job  had classpath  with xercesImpl-2.11 and jimage-created rt.jar for jython.)
  But non-english worlds behave strangely:
- property string were showed with  ? or incorrect characters in menu
- any stored world was corrupted so it could not be loaded later

  I assume that file.encoding=UTF-8 overrules ISO-8851-1 behavior on java <=8,
but real UTF-8 usage for java > 8 must be explicit mentioned in Alice code.
My corrections solve both problems and work also on java 8.