### PR TITLE
enable Tutorial eventButton hole for non-english properties 

### DIFF
--- a/src/main/java/edu/cmu/cs/stage3/alice/authoringtool/AuthoringTool.java
+++ b/src/main/java/edu/cmu/cs/stage3/alice/authoringtool/AuthoringTool.java
@@ -4373,7 +4373,7 @@ public class AuthoringTool implements java.awt.datatransfer.ClipboardOwner, edu.
 					prefix = AuthoringToolResources.getPrefix(token);
 					spec = AuthoringToolResources.getSpecifier(token);
 					if (prefix.equals("createNewEventButton")) { 
-						java.awt.Component c = AuthoringToolResources.findButton(jAliceFrame.behaviorGroupsEditor, "create new event"); 
+						java.awt.Component c = AuthoringToolResources.findButton(jAliceFrame.behaviorGroupsEditor, Messages.getString("create_new_event")); 
 						if (c != null) {
 							r = c.getBounds();
 							r = javax.swing.SwingUtilities.convertRectangle(c.getParent(), r, jAliceFrame.getGlassPane());


### PR DESCRIPTION
Solves fully issue10 when Tutorial3.stl page 17 Oops when non-english Alice language is set.
Instead, Page 17 shows hole for createNewEventButton and allows to choose the event type.
/I assume Alice Style.py already with # coding=utf-8/

Further processing is possible only on localized clones of Tutorial3, because of different names of stencil variables.
This is OK, any user  can now write his own .stl according .a2w localized variable naming rules.
For example in German:  ereignis instead event2, ereingis2 instead of event3 ... inside stencil stateCapsule.

I can mail an example, if needed. 

